### PR TITLE
Docs/macos build prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ pip install gradbot
 
 Or run a demo directly (builds from source):
 
+> **macOS prerequisite:** the demos build the Rust/C audio stack from source, which requires `opus` and `pkg-config`:
+> ```bash
+> brew install opus pkg-config
+> ```
+
 ```bash
 cd demos/simple_chat
 uv sync


### PR DESCRIPTION
`uv sync` in demo dirs compiles a Rust/C audio layer that links against libopus. On a fresh macOS machine neither `opus` nor `pkg-config` are present, causing an opaque CMake/cargo build failure. 

One `brew install` line before the `uv sync` step prevents this.