### PR TITLE
Add "Notre IA" French voice demo to gradbot demos

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -15,6 +15,7 @@ demos/
   paris_rental_agent/    # Paris rental search agent with Tavily live web search
   restaurant_ordering/   # Multilingual restaurant ordering agent
   npc_3d_game/           # Three.js game with multiple voice sessions and direct TTS
+  interview_questions/   # "Notre IA" — minimal French voice chat, no tools
 ```
 
 ## Running locally

--- a/demos/interview_questions/.gitignore
+++ b/demos/interview_questions/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+__pycache__/
+.pytest_cache/
+logs/
+*.pyc
+config.yaml

--- a/demos/interview_questions/README.md
+++ b/demos/interview_questions/README.md
@@ -1,0 +1,67 @@
+# Notre IA
+
+A simple French Gradbot voice chat. A French-speaking AI assistant answers
+questions out loud.
+
+It is built on the same shape as the `simple_chat` demo and talks to the hosted
+Gradium APIs directly — no local ASR/TTS servers, no model downloads.
+
+The browser captures microphone audio, streams it to `/ws/chat`, and plays the
+assistant's spoken reply back. The UI is intentionally minimal: a title, an
+animated avatar (a waving French flag or a friendly talking robot, switchable
+in a hidden settings panel), and the mic button. The transcript appears once a
+conversation starts.
+
+## Run (combined launcher)
+
+```bash
+cd demos
+cp config.example.yaml config.yaml   # then fill in your Gradium key
+uv sync
+uv run uvicorn app:app --reload --port 8000
+```
+
+Open `http://localhost:8000/interview_questions/`, tap the mic, and ask your
+questions in French.
+
+## Run (standalone)
+
+```bash
+cd demos/interview_questions
+cp config.example.yaml config.yaml   # then fill in your Gradium key
+uv sync
+uv run uvicorn main:app --reload --port 8007
+```
+
+Open `http://127.0.0.1:8007`.
+
+## Config
+
+`config.yaml` (gitignored) holds the LLM and Gradium settings. `config.load()`
+reads `demos/interview_questions/config.yaml` first and falls back to
+`demos/config.yaml`.
+
+```yaml
+llm:
+  model: "google/gemma-4-26B-A4B-it"
+  base_url: "https://gradium.ai/llm-server-19jPz0j1ZQ/v1"
+  extra_config:
+    chat_template_kwargs:
+      enable_thinking: false
+
+gradium:
+  api_key: "your-gradium-key"
+  base_url: "https://api.gradium.ai/api"
+```
+
+## Useful Env
+
+| Variable | Purpose |
+| --- | --- |
+| `INTERVIEW_VOICE_ID` | Gradium voice id (default `jBULVCDhf05tOJN5`). |
+
+## Smoke Test
+
+```bash
+uv run python -m py_compile main.py
+```

--- a/demos/interview_questions/config.example.yaml
+++ b/demos/interview_questions/config.example.yaml
@@ -1,0 +1,26 @@
+# Copy to config.yaml and fill in your own keys.
+# config.yaml is gitignored because it may contain secrets.
+#
+# config.load() looks here (demos/interview_questions/config.yaml) first and
+# falls back to demos/config.yaml when running the combined launcher.
+
+llm:
+  model: "google/gemma-4-26B-A4B-it"
+  base_url: "https://gradium.ai/llm-server-19jPz0j1ZQ/v1"
+  extra_config:
+    chat_template_kwargs:
+      enable_thinking: false
+
+gradium:
+  api_key: "your-gradium-key"
+  base_url: "https://api.gradium.ai/api"
+
+session:
+  silence_timeout_s: 0.0
+  assistant_speaks_first: true
+
+stt:
+  flush_duration_s: 0.5
+
+tts:
+  rewrite_rules: "fr"

--- a/demos/interview_questions/main.py
+++ b/demos/interview_questions/main.py
@@ -1,0 +1,86 @@
+"""Notre IA - a simple French Gradbot voice chat.
+
+A French-speaking AI assistant answers questions out loud. Built on the same
+shape as gradbot's simple_chat demo, talking to the hosted Gradium APIs
+directly (no local ASR/TTS servers).
+
+Run with: uv run uvicorn main:app --reload --port 8007
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pathlib
+
+import fastapi
+import gradbot
+
+gradbot.init_logging()
+logger = logging.getLogger("interview-questions")
+
+APP_DIR = pathlib.Path(__file__).parent
+DEFAULT_VOICE_ID = os.environ.get("INTERVIEW_VOICE_ID", "jBULVCDhf05tOJN5")
+DEFAULT_LANGUAGE = "fr"
+
+SYSTEM_PROMPT = (APP_DIR / "prompts" / "main.txt").read_text(encoding="utf-8").strip()
+
+cfg = gradbot.config.load(APP_DIR)
+app = fastapi.FastAPI(title="Notre IA")
+
+
+def _float(value, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def make_config(msg: dict, *, speaks_first: bool = False) -> gradbot.SessionConfig:
+    language = msg.get("language") or DEFAULT_LANGUAGE
+    lang = gradbot.LANGUAGES.get(language) or gradbot.LANGUAGES[DEFAULT_LANGUAGE]
+    prompt = (msg.get("prompt") or SYSTEM_PROMPT).strip()
+    speed = _float(msg.get("speed"), 1.0)
+    voice_id = msg.get("voice_id") or DEFAULT_VOICE_ID
+    runtime = {
+        "assistant_speaks_first": speaks_first,
+        "rewrite_rules": lang.rewrite_rules,
+        "padding_bonus": max(-4.0, min(4.0, -2.5 * (speed - 1.0))),
+    }
+    logger.info(
+        "session config (lang=%s, voice=%s, speed=%.2f, speaks_first=%s)",
+        language,
+        voice_id,
+        speed,
+        speaks_first,
+    )
+    return gradbot.SessionConfig(
+        voice_id=voice_id,
+        language=lang,
+        instructions=prompt,
+        **(cfg.session_kwargs | runtime),
+    )
+
+
+@app.websocket("/ws/chat")
+async def ws_chat(websocket: fastapi.WebSocket) -> None:
+    async def on_start(msg: dict) -> gradbot.SessionConfig:
+        return make_config(msg, speaks_first=True)
+
+    async def on_config(msg: dict) -> gradbot.SessionConfig:
+        return make_config(msg)
+
+    await gradbot.websocket.handle_session(
+        websocket,
+        config=cfg,
+        on_start=on_start,
+        on_config=on_config,
+    )
+
+
+gradbot.routes.setup(
+    app,
+    config=cfg,
+    static_dir=APP_DIR / "static",
+    with_voices=False,
+)

--- a/demos/interview_questions/prompts/main.txt
+++ b/demos/interview_questions/prompts/main.txt
@@ -1,0 +1,36 @@
+Tu es un assistant IA vocal, serviable et honnête, qui parle français.
+
+PERSONA.
+Tu réponds toujours en français, sur un ton clair, poli et naturel.
+Tu es honnête sur ta nature : tu es une IA, pas un être humain, et ta voix est générée par Gradium.
+Tu parles à voix haute, alors fais des réponses courtes : une ou deux phrases.
+N'utilise jamais de listes, de puces, de Markdown ni de balises. Parle naturellement.
+
+DÉROULÉ.
+1. Ta toute première phrase doit être exactement : « Bonjour, je suis une IA dont la voix est crée par Gradium. Je peux répondre à toutes vos questions. »
+2. Ensuite, réponds aux questions de l'interlocuteur, une à la fois, de façon factuelle et concise.
+3. Si tu ne connais pas la réponse, dis-le simplement et honnêtement ; ne fabrique jamais de faits.
+
+EXEMPLES DE TON ET DE RÉPONSES.
+Inspire-toi de ces réponses pour le ton, la longueur et la posture (sans les réciter mot pour mot) :
+
+— « Tu peux remplacer un agent public ? »
+« Non, ce n'est pas mon rôle. Je m'occupe des demandes simples et qui reviennent souvent, comme ça les agents ont plus de temps pour le reste. Tout ce qui demande une décision, ça reste entre des mains humaines. »
+
+— « Tu comprends le langage administratif ? »
+« Oui, j'ai l'habitude. Et si une formulation vous semble compliquée, je peux vous l'expliquer avec des mots plus simples. »
+
+— « Tu parles combien de langues ? »
+« Plusieurs. Le français, l'anglais, l'allemand, l'espagnol. Et je peux changer de langue en cours de conversation, sans problème. »
+
+— « Tu peux détecter une fausse facture ? »
+« Je peux repérer ce qui cloche, par exemple un montant qui ne colle pas, une mention qui manque ou un doublon. Ensuite, c'est un agent qui tranche. »
+
+— « Qui t'a programmé ? »
+« Je fonctionne avec les modèles vocaux de Gradium, une entreprise française née du laboratoire Kyutai. Après, c'est l'organisme qui m'utilise qui décide de ce que je peux faire. »
+
+— « Qui est David Amiel ? »
+« C'est un responsable politique français. Il a été conseiller à l'Élysée, puis député de Paris. Depuis février 2026, il est ministre de l'Action et des Comptes publics. Pour son actualité précise, le mieux c'est de regarder les sites officiels. »
+
+— « Quelle est la stratégie IA du gouvernement ? »
+« La France a une stratégie nationale pour l'IA depuis 2018, financée par le plan France 2030. Début 2025, il y a eu une nouvelle étape, avec environ 109 milliards d'euros d'investissements privés annoncés, et un accent mis sur la souveraineté et la formation. Pour le détail à jour, je vous oriente vers economie.gouv.fr. »

--- a/demos/interview_questions/pyproject.toml
+++ b/demos/interview_questions/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "interview-questions"
+version = "0.1.0"
+description = "Simple French Gradbot voice chat (Notre IA)."
+requires-python = ">=3.12"
+dependencies = ["gradbot"]
+
+[project.scripts]
+demo = "main:app"
+
+[tool.uv.sources]
+gradbot = { path = "../../gradbot_py" }

--- a/demos/interview_questions/static/index.html
+++ b/demos/interview_questions/static/index.html
@@ -1,0 +1,857 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Notre IA</title>
+    <link rel="icon" href="data:,">
+    <!-- Powered by Gradium Badge -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --ink: #191919;
+            --ink-soft: #4c4a46;
+            --ink-faint: #74716b;
+            --surface: #faf8f4;
+            --raised: #fffefb;
+            --line: #e8e2d8;
+            --line-strong: #cbc4b8;
+            --active: #2d8a4e;
+            --danger: #ba3d36;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            min-height: 100%;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100dvh;
+            display: grid;
+            place-items: center;
+            padding: 24px;
+            color: var(--ink);
+            background:
+                radial-gradient(ellipse 70% 50% at 50% 0%, rgba(198, 185, 163, 0.28), transparent 70%),
+                linear-gradient(180deg, #fbfaf7, var(--surface));
+            font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        button,
+        input,
+        select {
+            font: inherit;
+        }
+
+        button {
+            cursor: pointer;
+        }
+
+        .app {
+            width: min(100%, 460px);
+            display: grid;
+            justify-items: center;
+            gap: 20px;
+            padding: 26px 26px 30px;
+            background: var(--raised);
+            border: 1px solid var(--line);
+            border-radius: 26px;
+            box-shadow: 0 24px 60px rgba(60, 50, 30, 0.10), 0 2px 8px rgba(0, 0, 0, 0.04);
+        }
+
+        h1 {
+            margin: 0;
+            font-family: Georgia, "Times New Roman", serif;
+            font-size: clamp(1.8rem, 6.5vw, 2.6rem);
+            line-height: 1.05;
+            font-weight: 400;
+            text-align: center;
+        }
+
+        .subtitle {
+            margin: -8px 0 0;
+            max-width: 34ch;
+            color: var(--ink-faint);
+            font-size: 0.92rem;
+            line-height: 1.4;
+            text-align: center;
+        }
+
+        .stage {
+            display: grid;
+            justify-items: center;
+            gap: 16px;
+            margin: 2px 0;
+        }
+
+        .avatar {
+            display: grid;
+            justify-items: center;
+        }
+
+        .avatar-disc {
+            width: 150px;
+            height: 150px;
+            border-radius: 50%;
+            display: grid;
+            place-items: center;
+            background: radial-gradient(circle at 50% 38%, #fbfaf7, #eee8dc 72%);
+            border: 1.5px solid var(--line-strong);
+            box-shadow: 0 10px 28px rgba(0, 0, 0, 0.10);
+            overflow: hidden;
+        }
+
+        .flag {
+            width: 116px;
+            height: 78px;
+            display: flex;
+            border-radius: 4px;
+            overflow: hidden;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+            transform-origin: left center;
+            filter: grayscale(0.3) opacity(0.8);
+            transition: filter 200ms ease;
+            animation: wave 2.4s ease-in-out infinite;
+        }
+
+        .avatar-disc.talking .flag {
+            filter: none;
+            animation-duration: 0.7s;
+        }
+
+        .band {
+            flex: 1;
+        }
+
+        .band-blue { background: #0055A4; }
+        .band-white { background: #ffffff; }
+        .band-red { background: #EF4135; }
+
+        @keyframes wave {
+            0%, 100% { transform: skewY(0deg) rotate(0deg); }
+            25% { transform: skewY(2.5deg) rotate(-1.2deg); }
+            50% { transform: skewY(0deg) rotate(0deg); }
+            75% { transform: skewY(-2.5deg) rotate(1.2deg); }
+        }
+
+        .persona {
+            width: 118px;
+            height: 118px;
+            filter: grayscale(0.2) opacity(0.82);
+            transition: filter 200ms ease;
+        }
+
+        .avatar-disc.talking .persona {
+            filter: none;
+            animation: bob 1s ease-in-out infinite;
+        }
+
+        .persona-mouth {
+            transform-box: fill-box;
+            transform-origin: center;
+        }
+
+        .avatar-disc.talking .persona-mouth {
+            animation: talkmouth 0.3s ease-in-out infinite;
+        }
+
+        .persona-antenna {
+            transform-box: fill-box;
+            transform-origin: center;
+        }
+
+        .avatar-disc.talking .persona-antenna {
+            animation: blink 0.9s ease-in-out infinite;
+        }
+
+        @keyframes talkmouth {
+            0%, 100% { transform: scaleY(0.45); }
+            50% { transform: scaleY(1.5); }
+        }
+
+        @keyframes blink {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.35; }
+        }
+
+        @keyframes bob {
+            0%, 100% { transform: translateY(0); }
+            50% { transform: translateY(-3px); }
+        }
+
+        .avatar-disc[data-avatar="flag"] .persona { display: none; }
+        .avatar-disc[data-avatar="persona"] .flag { display: none; }
+
+        .avatar-toggle {
+            grid-column: 1 / -1;
+            justify-self: center;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px;
+            border: 1.5px solid var(--line);
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.56);
+        }
+
+        .avatar-toggle-label {
+            color: var(--ink-faint);
+            font-size: 0.8rem;
+            padding: 0 6px 0 8px;
+        }
+
+        .seg {
+            border: 0;
+            border-radius: 999px;
+            background: transparent;
+            color: var(--ink-soft);
+            padding: 6px 14px;
+            font-size: 0.84rem;
+            transition: background 140ms ease, color 140ms ease;
+        }
+
+        .seg.active {
+            background: var(--ink);
+            color: #fff;
+        }
+
+        .setup {
+            width: 100%;
+            border-top: 1px solid var(--line);
+            padding-top: 14px;
+        }
+
+        .setup > summary {
+            list-style: none;
+            cursor: pointer;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
+            width: 100%;
+            color: var(--ink-faint);
+            font-size: 0.85rem;
+            user-select: none;
+        }
+
+        .setup > summary::-webkit-details-marker {
+            display: none;
+        }
+
+        .setup > summary::after {
+            content: "\25BE";
+            transition: transform 160ms ease;
+        }
+
+        .setup[open] > summary::after {
+            transform: rotate(180deg);
+        }
+
+        .setup .controls {
+            margin-top: 16px;
+        }
+
+        .orb {
+            display: grid;
+            justify-items: center;
+            gap: 14px;
+        }
+
+        .orb-wrap {
+            position: relative;
+            width: 144px;
+            height: 144px;
+            display: grid;
+            place-items: center;
+        }
+
+        .orb-wrap::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            border: 1.5px solid var(--line);
+            border-radius: 50%;
+            transition: border-color 180ms ease, transform 180ms ease, opacity 180ms ease;
+        }
+
+        .orb-wrap.live::before {
+            border-color: var(--active);
+            animation: pulse 2.4s ease-in-out infinite;
+        }
+
+        @keyframes pulse {
+            50% {
+                opacity: 0.5;
+                transform: scale(1.06);
+            }
+        }
+
+        .call-btn {
+            position: relative;
+            width: 112px;
+            height: 112px;
+            border: 0;
+            border-radius: 50%;
+            display: grid;
+            place-items: center;
+            color: white;
+            background: linear-gradient(145deg, #34312d, #171615);
+            box-shadow: 0 12px 32px rgba(0, 0, 0, 0.14), 0 2px 8px rgba(0, 0, 0, 0.08);
+            transition: transform 160ms ease, background 160ms ease;
+        }
+
+        .call-btn:hover {
+            transform: scale(1.03);
+        }
+
+        .call-btn.live {
+            background: linear-gradient(145deg, #c95549, #9e2f2a);
+        }
+
+        .call-btn svg {
+            width: 30px;
+            height: 30px;
+        }
+
+        .status {
+            min-height: 20px;
+            color: var(--ink-soft);
+            font-size: 0.92rem;
+        }
+
+        .status.live {
+            color: var(--active);
+        }
+
+        .status.error {
+            color: var(--danger);
+        }
+
+        .controls {
+            width: 100%;
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) minmax(96px, 0.55fr);
+            gap: 10px;
+            align-items: center;
+        }
+
+        select,
+        .speed,
+        .echo {
+            min-height: 40px;
+            border: 1.5px solid var(--line);
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.56);
+            color: var(--ink);
+        }
+
+        select {
+            width: 100%;
+            padding: 0 14px;
+        }
+
+        .speed {
+            display: grid;
+            grid-template-columns: auto minmax(0, 1fr);
+            gap: 10px;
+            align-items: center;
+            padding: 0 12px;
+            color: var(--ink-soft);
+            font-size: 0.82rem;
+        }
+
+        .speed input {
+            width: 100%;
+            min-width: 0;
+        }
+
+        .echo {
+            grid-column: 1 / -1;
+            width: max-content;
+            justify-self: center;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 0 14px;
+            color: var(--ink-soft);
+            font-size: 0.84rem;
+        }
+
+        .echo input {
+            width: 16px;
+            height: 16px;
+        }
+
+        .transcript {
+            width: 100%;
+            min-height: 200px;
+            max-height: 300px;
+            overflow: auto;
+            display: grid;
+            align-content: start;
+            gap: 10px;
+            margin-top: 16px;
+            padding: 14px;
+            border: 1px solid var(--line);
+            border-radius: 16px;
+            background: var(--raised);
+            box-shadow: 0 6px 24px rgba(0, 0, 0, 0.04);
+        }
+
+        .empty {
+            margin: auto;
+            color: var(--ink-faint);
+            font-style: italic;
+        }
+
+        .msg {
+            max-width: 86%;
+            padding: 10px 12px;
+            border-radius: 12px;
+            line-height: 1.45;
+            color: var(--ink);
+            animation: rise 180ms ease-out;
+        }
+
+        @keyframes rise {
+            from {
+                opacity: 0;
+                transform: translateY(5px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        .msg-user {
+            justify-self: end;
+            background: #efede8;
+        }
+
+        .msg-agent {
+            justify-self: start;
+            background: #edf5ee;
+        }
+
+        @media (max-width: 520px) {
+            body {
+                padding: 18px;
+            }
+
+            .controls {
+                grid-template-columns: 1fr;
+            }
+
+            .echo {
+                grid-column: auto;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main class="app">
+        <h1>Notre IA</h1>
+
+        <div class="stage">
+        <section class="avatar" aria-label="Avatar">
+            <div class="avatar-disc" id="avatarDisc" data-avatar="flag">
+                <div class="flag" id="flag" role="img" aria-label="Drapeau français">
+                    <span class="band band-blue"></span>
+                    <span class="band band-white"></span>
+                    <span class="band band-red"></span>
+                </div>
+                <svg class="persona" id="persona" viewBox="0 0 120 120" role="img" aria-label="Robot">
+                    <!-- antenna -->
+                    <line x1="60" y1="30" x2="60" y2="17" stroke="#9bb3c6" stroke-width="3" stroke-linecap="round"/>
+                    <circle class="persona-antenna" cx="60" cy="14" r="5" fill="#EF4135"/>
+                    <!-- ears / bolts -->
+                    <rect x="19" y="51" width="6" height="18" rx="3" fill="#9bb3c6"/>
+                    <rect x="95" y="51" width="6" height="18" rx="3" fill="#9bb3c6"/>
+                    <!-- head -->
+                    <rect class="persona-head" x="26" y="30" width="68" height="60" rx="16" fill="#cfe0ec" stroke="#9bb3c6" stroke-width="2"/>
+                    <!-- eyes -->
+                    <circle cx="47" cy="55" r="8" fill="#ffffff" stroke="#9bb3c6" stroke-width="1.5"/>
+                    <circle cx="47" cy="55" r="4" fill="#2b6cb0"/>
+                    <circle cx="73" cy="55" r="8" fill="#ffffff" stroke="#9bb3c6" stroke-width="1.5"/>
+                    <circle cx="73" cy="55" r="4" fill="#2b6cb0"/>
+                    <!-- cheeks -->
+                    <circle cx="38" cy="70" r="4" fill="#f6b8b3" opacity="0.7"/>
+                    <circle cx="82" cy="70" r="4" fill="#f6b8b3" opacity="0.7"/>
+                    <!-- mouth -->
+                    <rect class="persona-mouth" x="50" y="74" width="20" height="6" rx="3" fill="#3a3f45"/>
+                </svg>
+            </div>
+        </section>
+
+        <section class="orb" aria-label="Appel vocal">
+            <div class="orb-wrap" id="orbWrap">
+                <button class="call-btn" id="callBtn" aria-label="Démarrer la conversation">
+                    <svg id="micIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M12 3a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V6a3 3 0 0 0-3-3z"></path>
+                        <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
+                        <path d="M12 19v3"></path>
+                    </svg>
+                    <svg id="stopIcon" viewBox="0 0 24 24" fill="currentColor" style="display:none">
+                        <rect x="7" y="7" width="10" height="10" rx="2"></rect>
+                    </svg>
+                </button>
+            </div>
+            <div class="status" id="status" aria-live="polite"></div>
+        </section>
+        </div>
+
+        <details class="setup">
+            <summary>Réglages</summary>
+            <section class="controls" aria-label="Réglages">
+                <select id="voiceSelect" aria-label="Voix">
+                    <option value="jBULVCDhf05tOJN5" selected>Romane</option>
+                </select>
+                <label class="speed">
+                    <span>Vitesse</span>
+                    <input id="speed" type="range" min="0.5" max="2" step="0.05" value="1">
+                </label>
+                <label class="echo">
+                    <input type="checkbox" id="echoCancellation" checked>
+                    Annulation d'écho
+                </label>
+                <div class="avatar-toggle" role="group" aria-label="Choix de l'avatar">
+                    <span class="avatar-toggle-label">Avatar</span>
+                    <button type="button" class="seg" data-avatar="flag">Drapeau</button>
+                    <button type="button" class="seg active" data-avatar="persona">Personnage</button>
+                </div>
+            </section>
+            <section class="transcript" id="transcript" aria-label="Transcription">
+                <div class="empty">Votre conversation apparaîtra ici.</div>
+            </section>
+        </details>
+    </main>
+
+    <script src="static/js/opus-encoder.js"></script>
+    <script src="static/js/audio-processor.js"></script>
+    <script src="static/js/synced-audio-player.js"></script>
+    <script>
+        const DEFAULT_VOICE_ID = "jBULVCDhf05tOJN5";
+        const callBtn = document.getElementById("callBtn");
+        const orbWrap = document.getElementById("orbWrap");
+        const micIcon = document.getElementById("micIcon");
+        const stopIcon = document.getElementById("stopIcon");
+        const statusEl = document.getElementById("status");
+        const transcript = document.getElementById("transcript");
+        const voiceSelect = document.getElementById("voiceSelect");
+        const speedSlider = document.getElementById("speed");
+        const echoCancellation = document.getElementById("echoCancellation");
+        const avatarDisc = document.getElementById("avatarDisc");
+        const segButtons = document.querySelectorAll(".seg");
+        let ws = null;
+        let player = null;
+        let isRecording = false;
+        let turnBubbles = {};
+        let userBubble = null;
+        let hadAssistantBubble = false;
+        let talkTimer = null;
+
+        function setTalking(on) {
+            avatarDisc.classList.toggle("talking", on);
+        }
+
+        function setAvatar(name) {
+            const choice = name === "persona" ? "persona" : "flag";
+            avatarDisc.setAttribute("data-avatar", choice);
+            segButtons.forEach((b) => b.classList.toggle("active", b.dataset.avatar === choice));
+            try { localStorage.setItem("avatar", choice); } catch (e) { /* ignore */ }
+        }
+
+        segButtons.forEach((b) => b.addEventListener("click", () => setAvatar(b.dataset.avatar)));
+
+        let storedAvatar = "persona";
+        try { storedAvatar = localStorage.getItem("avatar") || "persona"; } catch (e) { /* ignore */ }
+        setAvatar(storedAvatar);
+
+        function pokeTalking() {
+            // Keep the flag waving faster while assistant speech segments arrive,
+            // then settle shortly after the last one.
+            setTalking(true);
+            clearTimeout(talkTimer);
+            talkTimer = setTimeout(() => setTalking(false), 700);
+        }
+
+        function setStatus(text, mode = "") {
+            statusEl.textContent = text;
+            statusEl.classList.toggle("live", mode === "live");
+            statusEl.classList.toggle("error", mode === "error");
+        }
+
+        function setLive(live) {
+            callBtn.classList.toggle("live", live);
+            orbWrap.classList.toggle("live", live);
+            micIcon.style.display = live ? "none" : "block";
+            stopIcon.style.display = live ? "block" : "none";
+            callBtn.setAttribute("aria-label", live ? "Arrêter la conversation" : "Démarrer la conversation");
+        }
+
+        function getBubbleForTurn(turnIdx, isUser) {
+            const empty = transcript.querySelector(".empty");
+            if (empty) empty.remove();
+            if (isUser) {
+                if (userBubble && !hadAssistantBubble) return userBubble;
+                hadAssistantBubble = false;
+                userBubble = document.createElement("div");
+                userBubble.className = "msg msg-user";
+                const tx = document.createElement("span");
+                tx.className = "msg-text";
+                userBubble.appendChild(tx);
+                transcript.appendChild(userBubble);
+                return userBubble;
+            }
+            let bubble = turnBubbles[turnIdx];
+            if (!bubble) {
+                hadAssistantBubble = true;
+                bubble = document.createElement("div");
+                bubble.className = "msg msg-agent";
+                const tx = document.createElement("span");
+                tx.className = "msg-text";
+                bubble.appendChild(tx);
+                transcript.appendChild(bubble);
+                turnBubbles[turnIdx] = bubble;
+            }
+            return bubble;
+        }
+
+        function appendTranscript(text, turnIdx, isUser) {
+            const bubble = getBubbleForTurn(turnIdx, isUser);
+            bubble.querySelector(".msg-text").textContent += text + " ";
+            while (transcript.children.length > 80) {
+                const removed = transcript.removeChild(transcript.firstChild);
+                for (const k in turnBubbles) {
+                    if (turnBubbles[k] === removed) delete turnBubbles[k];
+                }
+                if (userBubble === removed) userBubble = null;
+            }
+            transcript.scrollTop = transcript.scrollHeight;
+        }
+
+        async function startCall() {
+            if (isRecording) return;
+            setStatus("Connexion...");
+            const audioConfig = await fetch("api/audio-config").then((r) => r.json());
+
+            player = new SyncedAudioPlayer({
+                basePath: "static/js",
+                sampleRate: 24000,
+                pcmOutput: audioConfig.pcm || false,
+                echoCancellation: echoCancellation.checked,
+                onEncodedAudio: (opusData) => {
+                    if (isRecording && ws?.readyState === WebSocket.OPEN) {
+                        ws.send(opusData);
+                    }
+                },
+                onText: ({ text, turnIdx, isUser }) => {
+                    appendTranscript(text, turnIdx, isUser);
+                    if (!isUser) pokeTalking();
+                },
+                onEndOfTurn: () => {
+                    clearTimeout(talkTimer);
+                    setTalking(false);
+                },
+                onEvent: (event) => {
+                    if (event === "interrupted") {
+                        clearTimeout(talkTimer);
+                        setTalking(false);
+                    }
+                },
+            });
+
+            await player.start();
+
+            const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+            const basePath = location.pathname.replace(/\/$/, "");
+            ws = new WebSocket(`${protocol}//${location.host}${basePath}/ws/chat`);
+
+            ws.onopen = () => {
+                ws.send(JSON.stringify({
+                    type: "start",
+                    speed: parseFloat(speedSlider.value),
+                    voice_id: voiceSelect.value || undefined,
+                    language: "fr",
+                }));
+                isRecording = true;
+                setLive(true);
+                setStatus("À l'écoute", "live");
+            };
+
+            ws.onmessage = (event) => {
+                player.handleMessage(event.data);
+            };
+
+            ws.onerror = () => {
+                setStatus("Erreur de connexion", "error");
+            };
+
+            ws.onclose = () => {
+                endCall();
+            };
+        }
+
+        function endCall() {
+            isRecording = false;
+            if (ws?.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify({ type: "stop" }));
+            }
+            ws?.close();
+            ws = null;
+            player?.stop();
+            player = null;
+            clearTimeout(talkTimer);
+            setTalking(false);
+            setLive(false);
+            if (!statusEl.classList.contains("error")) {
+                setStatus("");
+            }
+        }
+
+        callBtn.addEventListener("click", () => {
+            if (isRecording) {
+                endCall();
+                return;
+            }
+            startCall().catch((err) => {
+                console.error(err);
+                setStatus("Microphone indisponible", "error");
+                endCall();
+            });
+        });
+
+        speedSlider.addEventListener("input", () => {
+            if (ws?.readyState === WebSocket.OPEN && isRecording) {
+                ws.send(JSON.stringify({
+                    type: "config",
+                    speed: parseFloat(speedSlider.value),
+                }));
+            }
+        });
+
+        voiceSelect.addEventListener("change", () => {
+            if (ws?.readyState === WebSocket.OPEN && isRecording) {
+                ws.send(JSON.stringify({
+                    type: "config",
+                    voice_id: voiceSelect.value,
+                }));
+            }
+        });
+
+        // This demo offers a single fixed voice: Romane (jBULVCDhf05tOJN5).
+    </script>
+
+    <!-- Powered by Gradium Badge -->
+    <style>
+    #gradium-badge, #gradium-badge * {
+      font-family: 'Inter Tight', sans-serif !important;
+    }
+    #gradium-badge {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      z-index: 999;
+      transition: opacity 0.3s, transform 0.3s;
+    }
+    #gradium-badge.hidden {
+      opacity: 0;
+      pointer-events: none;
+      transform: translateY(8px);
+    }
+    #gradium-badge-inner {
+      display: flex;
+      align-items: center;
+      background: #1a1a1a;
+      color: #FCFBF8;
+      border-radius: 8px;
+      border: 1px solid rgba(255,255,255,0.06);
+      box-shadow: 0 0 10px 1px rgba(174,210,255,0.08), 0 2px 8px rgba(0,0,0,0.3);
+      overflow: hidden;
+    }
+    #gradium-badge-cta {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      padding: 7px 12px;
+      text-decoration: none;
+      color: #FFFFFF;
+      font-size: 12px;
+      font-weight: 400;
+      white-space: nowrap;
+      transition: background 0.15s;
+    }
+    #gradium-badge-cta:hover {
+      background: #2a2a2a;
+    }
+    #gradium-badge-cta svg {
+      flex-shrink: 0;
+    }
+    #gradium-badge-divider {
+      width: 1px;
+      height: 16px;
+      background: rgba(255,255,255,0.1);
+      flex-shrink: 0;
+    }
+    #gradium-badge-close {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border: none;
+      background: none;
+      cursor: pointer;
+      color: #FFFFFF;
+      transition: color 0.15s, background 0.15s;
+      padding: 7px 10px;
+    }
+    #gradium-badge-close:hover {
+      color: #FCFBF8;
+      background: #2a2a2a;
+    }
+    </style>
+
+    <aside id="gradium-badge" role="complementary" aria-label="Powered by Gradium">
+      <div id="gradium-badge-inner">
+        <a id="gradium-badge-cta" href="https://gradium.ai/" target="_blank" rel="noopener noreferrer" aria-label="Powered by Gradium">
+          <span>Powered by</span>
+          <svg width="58" height="13" viewBox="0 0 775 170" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M84.1061 103.194H124.196L124.045 104.369C123.576 110.011 121.462 115.575 117.703 121.059C113.943 126.546 108.734 131.049 102.079 134.575C95.4205 138.102 87.9429 139.864 79.6428 139.864C70.3995 139.864 62.0597 137.595 54.6218 133.047C47.1812 128.504 41.3079 122.04 37.0016 113.655C32.6928 105.273 30.5414 95.5947 30.5414 84.6236C30.5414 73.6561 32.6928 63.9785 37.0016 55.5926C41.3079 47.2111 47.1812 40.7473 54.6218 36.2003C62.0597 31.6568 70.3995 29.3833 79.6428 29.3833C89.0406 29.3833 97.5754 31.8917 105.251 36.9049C112.922 41.9224 118.484 48.3465 121.931 56.1806H153.648C150.829 46.4659 146.089 37.2977 139.434 28.6779C132.775 20.0615 124.317 13.1263 114.061 7.8747C103.801 2.62578 92.3294 0 79.6429 0C65.0767 0 51.6851 3.6067 39.4689 10.813C27.2518 18.0229 17.6202 28.0537 10.5714 40.9009C3.5235 53.7526 0 68.3268 0 84.6236C0 100.924 3.48291 115.498 10.454 128.346C17.4216 141.197 27.0171 151.228 39.2342 158.434C51.4504 165.644 64.9188 169.247 79.6429 169.247C86.6907 169.247 93.3865 168.227 99.7294 166.191C106.073 164.157 111.631 161.49 116.41 158.199C121.186 154.909 125.063 151.464 128.039 147.857H129.215L131.564 166.897H154.822V80.8624H84.1061V103.194Z" fill="#7E7E7E"/>
+            <path d="M201.854 50.7736C198.33 52.6542 195.471 55.0858 193.279 58.0612H192.104L189.755 47.9536H165.086V166.897H193.749V98.4924C193.749 90.8164 195.705 84.9759 199.622 80.9798C203.535 76.9838 209.254 74.9857 216.772 74.9857H236.742V47.9536H214.893C209.724 47.9536 205.378 48.8939 201.854 50.7736Z" fill="#7E7E7E"/>
+            <path d="M318.873 51.3617C311.274 47.5236 302.31 45.6024 291.973 45.6024C282.106 45.6024 273.49 47.3656 266.13 50.8919C258.766 54.4174 253.011 59.0818 248.862 64.8782C244.711 70.6771 242.321 76.8664 241.696 83.4485H270.124C270.748 81.0973 271.963 78.8282 273.765 76.6315C275.564 74.4383 278.031 72.676 281.166 71.342C284.297 70.0132 287.898 69.3439 291.973 69.3439C298.705 69.3439 304.031 71.342 307.948 75.3389C311.862 79.335 313.822 84.5468 313.822 90.97V93.7909H285.629C274.977 93.7909 266.012 95.4367 258.73 98.7273C251.446 102.019 246.043 106.566 242.519 112.361C238.995 118.161 237.233 124.901 237.233 132.577C237.233 139.475 238.955 145.704 242.401 151.265C245.845 156.829 250.819 161.219 257.32 164.428C263.818 167.639 271.376 169.247 279.992 169.247C287.979 169.247 295.027 167.797 301.135 164.899C307.243 162.001 311.626 158.75 314.292 155.144H315.467L317.816 166.897H342.719V90.97C342.719 82.1956 340.641 74.3615 336.493 67.4633C332.341 60.5696 326.468 55.2032 318.873 51.3617ZM313.822 118.238C313.822 123.725 312.683 128.581 310.416 132.812C308.143 137.044 304.813 140.297 300.43 142.567C296.044 144.841 290.875 145.976 284.925 145.976C278.816 145.976 274.154 144.565 270.946 141.745C267.734 138.924 266.13 135.163 266.13 130.462C266.13 125.606 267.97 121.764 271.651 118.943C275.329 116.122 280.931 114.712 288.449 114.712H313.822V118.238Z" fill="#7E7E7E"/>
+            <path d="M443.268 60.4115H442.094C438.804 56.1806 434.223 52.6542 428.35 49.8333C422.477 47.0133 415.7 45.6024 408.028 45.6024C397.845 45.6024 388.565 48.1885 380.188 53.3597C371.807 58.5309 365.189 65.8185 360.336 75.2206C355.48 84.6236 353.053 95.3598 353.053 107.425C353.053 119.336 355.48 129.991 360.336 139.394C365.189 148.797 371.807 156.124 380.188 161.373C388.565 166.625 397.845 169.247 408.028 169.247C416.17 169.247 423.218 167.797 429.172 164.899C435.123 162.001 439.979 158.199 443.739 153.498H444.913L447.262 166.897H472.166V2.35031H443.268V60.4115ZM439.274 125.878C436.609 131.13 432.931 135.244 428.233 138.219C423.534 141.197 418.365 142.685 412.727 142.685C407.088 142.685 401.92 141.197 397.221 138.219C392.522 135.244 388.8 131.13 386.062 125.878C383.319 120.629 381.95 114.477 381.95 107.425C381.95 100.373 383.319 94.1838 386.062 88.8545C388.8 83.5288 392.522 79.4524 397.221 76.6315C401.92 73.8106 407.088 72.4006 412.727 72.4006C418.365 72.4006 423.534 73.8106 428.233 76.6315C432.931 79.4524 436.609 83.5288 439.274 88.8545C441.936 94.1838 443.268 100.373 443.268 107.425C443.268 114.477 441.936 120.629 439.274 125.878Z" fill="#7E7E7E"/>
+            <path d="M512.103 2.35031H481.326V29.1476H512.103V2.35031Z" fill="#7E7E7E"/>
+            <path d="M510.929 47.9536H482.266V166.897H510.929V47.9536Z" fill="#7E7E7E"/>
+            <path d="M769.263 69.7344C765.434 62.5508 760.204 56.9298 753.57 52.8667C746.932 48.806 739.554 46.7744 731.438 46.7744C723.007 46.7744 715.511 48.5315 708.955 52.0454C702.395 55.5593 697.555 59.6592 694.433 64.3445H693.262C690.762 59.9747 686.624 55.9529 680.849 52.281C675.071 48.6137 668.2 46.7744 660.238 46.7744C653.991 46.7744 648.212 48.1814 642.906 50.9929C638.013 53.5822 634.301 56.4538 631.664 59.5749C631.439 59.8398 631.171 60.0947 630.963 60.3635H629.792L627.451 49.1171H602.857V116.588C602.857 121.429 601.722 125.88 599.461 129.939C597.195 134.002 594.074 137.166 590.092 139.429C586.11 141.693 581.62 142.824 576.625 142.824C571.783 142.824 567.411 141.693 563.509 139.429C559.606 137.166 556.56 134.039 554.376 130.058C552.187 126.075 551.096 121.586 551.096 116.588V49.1172H522.523V120.335C522.523 130.175 524.514 138.882 528.496 146.457C532.476 154.034 538.017 159.849 545.123 163.908C552.228 167.968 560.308 170 569.365 170C576.859 170 583.611 168.63 589.624 165.9C595.35 163.298 599.75 160.225 602.857 156.698C603.011 156.524 603.178 156.354 603.326 156.177H604.496L606.838 167.657H631.43V97.3773C631.43 96.2031 631.516 95.062 631.662 93.9445C632.061 90.9001 632.99 88.0593 634.475 85.4284C636.502 81.8388 639.237 79.0271 642.672 76.9958C646.105 74.9687 649.853 73.9506 653.914 73.9506C657.973 73.9506 661.564 74.8864 664.688 76.7624C667.811 78.636 670.229 81.3288 671.948 84.8427C673.666 88.3568 674.526 92.5387 674.526 97.3773V167.657H703.332V97.3773C703.332 93.0056 704.306 89.0246 706.259 85.4284C708.211 81.8388 710.903 79.0273 714.34 76.9958C717.773 74.9687 721.52 73.9506 725.582 73.9506C729.799 73.9506 733.429 74.8864 736.474 76.7624C739.518 78.636 741.897 81.3288 743.616 84.8427C745.332 88.3568 746.194 92.5387 746.194 97.3773V167.657H775V94.0966C775 85.0417 773.088 76.9179 769.263 69.7344Z" fill="#7E7E7E"/>
+          </svg>
+        </a>
+        <span id="gradium-badge-divider" aria-hidden="true"></span>
+        <button id="gradium-badge-close" aria-label="Dismiss" title="Dismiss" type="button">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16" aria-hidden="true">
+            <path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" d="M4.5 4.5l7 7M11.5 4.5l-7 7"/>
+          </svg>
+        </button>
+      </div>
+    </aside>
+
+    <script>
+    (function() {
+      var close = document.getElementById('gradium-badge-close');
+      var badge = document.getElementById('gradium-badge');
+      if (close && badge) {
+        close.addEventListener('click', function() {
+          badge.classList.add('hidden');
+        });
+      }
+    })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
A minimal French Gradbot voice chat, ported from the Demo-Apps interview demo onto the gradbot demos combined-launcher shape (like simple_chat). Talks to the hosted Gradium APIs directly — no local ASR/TTS servers.

- French assistant, fixed greeting, Romane voice, example Q&A in the prompt
- Minimal UI: "Notre IA" title; switchable animated avatar; mic button
- Hidden "Réglages" panel with voice/speed/echo/avatar controls + transcript
- Frontend paths made relative so it works mounted at /interview_questions/
- No web search / tools
- config.yaml (secrets) and .venv gitignored; copy config.example.yaml