### PR TITLE
Fix double answer on fast LLM backends: don't emit the PENDING holding turn for quick tools

### DIFF
--- a/gradbot_lib/src/multiplex.rs
+++ b/gradbot_lib/src/multiplex.rs
@@ -7,6 +7,18 @@ use tokio::sync::Mutex;
 pub const DEFAULT_FLUSH_FOR_S: f64 = 0.5;
 const INPUT_SAMPLE_RATE: usize = 24000;
 
+/// Minimum time an unanswered tool call may be outstanding before we inject a
+/// `PENDING` placeholder result and let the model speak a holding phrase while
+/// the tool runs. This must stay above typical fast-tool latency: with a fast
+/// LLM backend (sub-100ms) and a quick tool (a couple hundred ms), a very small
+/// threshold fires this "holding" generation on the empty PENDING result before
+/// the real result arrives — the model then verbalizes it (e.g. "I couldn't find
+/// any record of X"), and re-answers correctly once the result lands, producing a
+/// confusing double answer. Slower LLMs never showed this because the real result
+/// was always in context before they emitted a token. Keep the holding phrase for
+/// genuinely long-running tools only.
+const TOOL_WAIT_FILLER_S: f64 = 1.5;
+
 /// Internal commands sent from spawned tasks back to the main session loop.
 enum InternalCmd {
     /// Restart the STT stream to clear stuck state.
@@ -921,7 +933,7 @@ impl Session {
                 } else {
                     let elapsed = stt_time - since_s;
                     let has_new = self.llm.read().await.has_new_tool_calls().await;
-                    if elapsed > 0.05 && inactivity_prob > 0.8 && has_new {
+                    if elapsed > TOOL_WAIT_FILLER_S && inactivity_prob > 0.8 && has_new {
                         tracing::info!(
                             elapsed_ms = ((stt_time - since_s) * 1000.0) as u32,
                             inactivity_prob,

--- a/gradbot_lib/src/system_prompt.rs
+++ b/gradbot_lib/src/system_prompt.rs
@@ -99,6 +99,15 @@ completed and its result is now available in your context. Continue the conversa
 naturally based on the tool result - acknowledge the action, inform the user of
 what happened, or proceed with the next step.
 
+# TOOL RESULT NOT READY YET
+If a tool result's content is exactly "PENDING", that tool call has NOT finished yet -
+its real result is still on its way and will arrive shortly as another empty message. Do
+NOT act on a PENDING result or describe any outcome from it: do not state a result, do
+not say the action succeeded or failed, and do not conclude that nothing was found or
+that something does not exist - you have not actually received the result yet. Say at
+most a brief, natural holding phrase like "One moment." (or nothing at all), then wait
+for the real result before responding.
+
 # SILENCE AND CONVERSATION END
 If the user says "...", that means they haven't spoken for a while (this is different
 from an empty message which means tool results are ready).


### PR DESCRIPTION
## Problem

With a fast LLM backend (we hit this on **Cerebras**, ~30–50 ms TTFT) and a quick tool (~200 ms), the agent speaks **twice** on every tool-using turn:

```
Caller:    What was the result of the Brazil–Norway match?
Assistant: I couldn't find any record of a match between Brazil and Norway.   ← spurious, spoken first
Assistant: Norway won 2–1, Haaland brace … (per Al Jazeera).                  ← correct, from the tool result
```

The tool actually ran and returned good results — the first utterance is spurious.

## Root cause

In `multiplex.rs::on_step`, the branch that injects a `PENDING` placeholder tool result and triggers a "holding" generation fires at `elapsed > 0.05` (50 ms):

```rust
if elapsed > 0.05 && inactivity_prob > 0.8 && has_new {
    // inject PENDING (llm.rs) and generate a holding utterance
    self.llm_tts("", turn_idx).await
}
```

50 ms is shorter than essentially any real tool round-trip, so for **every** tool call the model is asked to respond to a `PENDING` result before the real one arrives. `process_pending_tool_calls` injects a tool message with content `"PENDING"` (`llm.rs`), but nothing in the default system prompt explains what `PENDING` means — so the model treats it as a finished/empty result and verbalizes a wrong answer (here, "I couldn't find…"). The real result then lands and it answers again → double answer.

Slower LLMs never showed this: the real result was always in context before they emitted their first token, so the `PENDING` generation was superseded.

We confirmed it deterministically: feeding a model a tool result of `"PENDING"` (or empty) reproduces the exact spurious sentence; with the real result it answers correctly.

## Fix (minimal, behavior-preserving)

- **`multiplex.rs`** — raise the holding-generation threshold from `0.05` to a named const `TOOL_WAIT_FILLER_S = 1.5`, so quick tools answer in a single turn and the holding phrase is reserved for genuinely long-running tools (its intended use).
- **`system_prompt.rs`** — add a `# TOOL RESULT NOT READY YET` section: a `PENDING` result means the tool hasn't finished; don't act on it or report any outcome, say at most a brief holding phrase ("One moment.") and wait for the real result. Written tool-agnostically (not search-specific), and this section is always included regardless of custom instructions.

`cargo build` and `cargo test -p gradbot` pass.

## Possible follow-up

If you'd prefer the threshold to be tunable per session, it could become a `SessionConfig` field (mirroring `silence_timeout_s`) instead of a const — happy to extend this PR if that's preferred.