### PR TITLE
Bump gradbot pip package version to 0.1.9

### DIFF
--- a/gradbot_py/pyproject.toml
+++ b/gradbot_py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "gradbot"
-version = "0.1.8"
+version = "0.1.9"
 description = "Python bindings for gradbot voice AI library"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump the `gradbot` Python package version from 0.1.8 to 0.1.9 in `gradbot_py/pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)