### PR TITLE
Fix Windows PyPI publish CI: pin CMake <4 for audiopus_sys build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,6 +99,8 @@ jobs:
         with:
           python-version: 3.13
           architecture: ${{ matrix.platform.python_arch }}
+      - name: Install CMake 3.x
+        run: pip install 'cmake<4'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
## Summary
- The Windows PyPI publish job fails building `audiopus_sys` because `maturin-action` picks up a CMake ≥4 on the runner, and CMake 4 dropped support for the old `cmake_minimum_required` version in the vendored `opus` CMakeLists.txt.
- The macOS job already works around this by installing `cmake<4` via pip before the build; this applies the same fix to the Windows job.

## Test plan
- [ ] Confirm the Windows wheel build step in CI succeeds past the `audiopus_sys` cmake configure step