### PR TITLE
Fix Windows CI: use CMAKE_POLICY_VERSION_MINIMUM instead of pinning CMake<4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,10 +99,10 @@ jobs:
         with:
           python-version: 3.13
           architecture: ${{ matrix.platform.python_arch }}
-      - name: Install CMake 3.x
-        run: pip install 'cmake<4'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path gradbot_py/Cargo.toml


### PR DESCRIPTION
## Summary
- The previous fix (pinning `cmake<4` via pip) fixed the "Compatibility with CMake < 3.5 has been removed" error, but broke Windows builds a different way: the older CMake doesn't recognize the "Visual Studio 18 2026" generator that `maturin-action` detects on the current `windows-latest` runner.
- Fix by keeping the runner's own (current) CMake, and instead setting `CMAKE_POLICY_VERSION_MINIMUM=3.5` as an env var on the build step. CMake reads this directly to relax the ancient `cmake_minimum_required` check in `audiopus_sys`'s vendored `opus` CMakeLists.txt, without needing an older CMake at all.

## Test plan
- [ ] Confirm the Windows wheel build step in CI configures and builds `audiopus_sys`/opus successfully