### PR TITLE
Add unit test suite for gradbot_server

### DIFF
--- a/gradbot_server/src/config.rs
+++ b/gradbot_server/src/config.rs
@@ -83,3 +83,91 @@ impl Config {
         Ok(config)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replace_env_vars_substitutes_set_variables() {
+        let key = "GRADBOT_SERVER_TEST_REPLACE_ENV_VARS_SET";
+        unsafe {
+            std::env::set_var(key, "hello");
+        }
+        let out = replace_env_vars(&format!("prefix-${key}-suffix"));
+        unsafe {
+            std::env::remove_var(key);
+        }
+        assert_eq!(out, "prefix-hello-suffix");
+    }
+
+    #[test]
+    fn replace_env_vars_treats_missing_variables_as_empty() {
+        let key = "GRADBOT_SERVER_TEST_REPLACE_ENV_VARS_MISSING";
+        unsafe {
+            std::env::remove_var(key);
+        }
+        let out = replace_env_vars(&format!("prefix-${key}-suffix"));
+        assert_eq!(out, "prefix--suffix");
+    }
+
+    #[test]
+    fn replace_env_vars_leaves_plain_text_untouched() {
+        let out = replace_env_vars("no variables here");
+        assert_eq!(out, "no variables here");
+    }
+
+    fn write_temp_config(name: &str, contents: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "gradbot_server_test_config_{name}_{:?}.toml",
+            std::thread::current().id()
+        ));
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn config_load_applies_defaults_for_missing_fields() {
+        let path = write_temp_config("defaults", "");
+        let config = Config::load(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(config.addr, "0.0.0.0");
+        assert_eq!(config.port, 8080);
+        assert_eq!(config.log_dir, "./logs");
+        assert!(!config.log_sessions);
+        assert_eq!(config.llm_base_url, None);
+    }
+
+    #[test]
+    fn config_load_substitutes_env_vars_in_llm_api_key() {
+        let key = "GRADBOT_SERVER_TEST_CONFIG_LOAD_API_KEY";
+        unsafe {
+            std::env::set_var(key, "secret-value");
+        }
+        let path = write_temp_config("env_substitution", &format!("llm_api_key = \"${key}\"\n"));
+
+        let config = Config::load(&path).unwrap();
+
+        std::fs::remove_file(&path).ok();
+        unsafe {
+            std::env::remove_var(key);
+        }
+
+        assert_eq!(config.llm_api_key, Some("secret-value".to_string()));
+    }
+
+    #[test]
+    fn config_load_respects_explicit_values() {
+        let path = write_temp_config(
+            "explicit",
+            "addr = \"127.0.0.1\"\nport = 9999\nlog_sessions = true\n",
+        );
+        let config = Config::load(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(config.addr, "127.0.0.1");
+        assert_eq!(config.port, 9999);
+        assert!(config.log_sessions);
+    }
+}

--- a/gradbot_server/src/protocol.rs
+++ b/gradbot_server/src/protocol.rs
@@ -234,3 +234,193 @@ pub fn merge_with_pinned(
 
     (merged.to_lib(), pinned_fields)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_lang_recognizes_all_known_codes() {
+        assert_eq!(parse_lang("fr"), gradbot::Lang::Fr);
+        assert_eq!(parse_lang("de"), gradbot::Lang::De);
+        assert_eq!(parse_lang("es"), gradbot::Lang::Es);
+        assert_eq!(parse_lang("pt"), gradbot::Lang::Pt);
+        assert_eq!(parse_lang("en"), gradbot::Lang::En);
+    }
+
+    #[test]
+    fn parse_lang_defaults_unknown_codes_to_english() {
+        assert_eq!(parse_lang("xx"), gradbot::Lang::En);
+        assert_eq!(parse_lang(""), gradbot::Lang::En);
+    }
+
+    #[test]
+    fn lang_round_trips_through_str() {
+        for lang in [
+            gradbot::Lang::En,
+            gradbot::Lang::Fr,
+            gradbot::Lang::De,
+            gradbot::Lang::Es,
+            gradbot::Lang::Pt,
+        ] {
+            assert_eq!(parse_lang(lang_to_str(lang)), lang);
+        }
+    }
+
+    #[test]
+    fn session_config_wire_to_lib_uses_defaults_when_empty() {
+        let wire = SessionConfigWire::default();
+        let config = wire.to_lib();
+
+        assert_eq!(config.voice_id, None);
+        assert_eq!(config.instructions, None);
+        assert_eq!(config.language, gradbot::Lang::En);
+        assert!(config.assistant_speaks_first);
+        assert_eq!(config.silence_timeout_s, 5.0);
+        assert!(config.tools.is_empty());
+        assert_eq!(config.flush_duration_s, gradbot::DEFAULT_FLUSH_FOR_S);
+        assert_eq!(config.padding_bonus, 0.0);
+    }
+
+    #[test]
+    fn session_config_wire_to_lib_honors_explicit_values() {
+        let wire = SessionConfigWire {
+            voice_id: Some("voice-1".to_string()),
+            instructions: Some("be terse".to_string()),
+            language: Some("de".to_string()),
+            assistant_speaks_first: Some(false),
+            silence_timeout_s: Some(2.5),
+            tools: Some(vec![ToolDefWire {
+                name: "lookup".to_string(),
+                description: "look things up".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            }]),
+            flush_duration_s: Some(1.0),
+            padding_bonus: Some(-2.0),
+            rewrite_rules: Some("de".to_string()),
+            stt_extra_config: None,
+            tts_extra_config: None,
+            llm_extra_config: None,
+        };
+
+        let config = wire.to_lib();
+
+        assert_eq!(config.voice_id, Some("voice-1".to_string()));
+        assert_eq!(config.language, gradbot::Lang::De);
+        assert!(!config.assistant_speaks_first);
+        assert_eq!(config.silence_timeout_s, 2.5);
+        assert_eq!(config.tools.len(), 1);
+        assert_eq!(config.tools[0].name, "lookup");
+        assert_eq!(config.flush_duration_s, 1.0);
+        assert_eq!(config.padding_bonus, -2.0);
+        assert_eq!(config.rewrite_rules, Some("de".to_string()));
+    }
+
+    #[test]
+    fn session_config_round_trips_through_wire() {
+        let original = gradbot::SessionConfig {
+            voice_id: Some("voice-2".to_string()),
+            instructions: None,
+            language: gradbot::Lang::Es,
+            assistant_speaks_first: false,
+            silence_timeout_s: 7.0,
+            tools: vec![gradbot::ToolDef {
+                name: "search".to_string(),
+                description: "search the web".to_string(),
+                parameters: serde_json::json!({}),
+            }],
+            flush_duration_s: 0.25,
+            padding_bonus: 1.5,
+            rewrite_rules: None,
+            stt_extra_config: None,
+            tts_extra_config: None,
+            llm_extra_config: None,
+        };
+
+        let wire = SessionConfigWire::from(&original);
+        let round_tripped = wire.to_lib();
+
+        assert_eq!(round_tripped.voice_id, original.voice_id);
+        assert_eq!(round_tripped.language, original.language);
+        assert_eq!(
+            round_tripped.assistant_speaks_first,
+            original.assistant_speaks_first
+        );
+        assert_eq!(round_tripped.silence_timeout_s, original.silence_timeout_s);
+        assert_eq!(round_tripped.tools.len(), 1);
+        assert_eq!(round_tripped.tools[0].name, "search");
+        assert_eq!(round_tripped.flush_duration_s, original.flush_duration_s);
+        assert_eq!(round_tripped.padding_bonus, original.padding_bonus);
+    }
+
+    #[test]
+    fn merge_with_pinned_overrides_client_fields() {
+        let client = SessionConfigWire {
+            voice_id: Some("client-voice".to_string()),
+            instructions: Some("client instructions".to_string()),
+            ..Default::default()
+        };
+        let pinned = SessionConfigWire {
+            voice_id: Some("pinned-voice".to_string()),
+            ..Default::default()
+        };
+
+        let (merged, pinned_fields) = merge_with_pinned(client, &pinned);
+
+        assert_eq!(merged.voice_id, Some("pinned-voice".to_string()));
+        assert_eq!(merged.instructions, Some("client instructions".to_string()));
+        assert_eq!(pinned_fields, vec!["voice_id".to_string()]);
+    }
+
+    #[test]
+    fn merge_with_pinned_falls_back_to_client_when_nothing_pinned() {
+        let client = SessionConfigWire {
+            voice_id: Some("client-voice".to_string()),
+            silence_timeout_s: Some(3.0),
+            ..Default::default()
+        };
+        let pinned = SessionConfigWire::default();
+
+        let (merged, pinned_fields) = merge_with_pinned(client, &pinned);
+
+        assert_eq!(merged.voice_id, Some("client-voice".to_string()));
+        assert_eq!(merged.silence_timeout_s, 3.0);
+        assert!(pinned_fields.is_empty());
+    }
+
+    #[test]
+    fn client_message_session_config_deserializes_from_tagged_json() {
+        let json = r#"{"type":"session.config","config":{"voice_id":"v1"}}"#;
+        let msg: ClientMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            ClientMessage::SessionConfig { config } => {
+                assert_eq!(config.voice_id, Some("v1".to_string()));
+            }
+            _ => panic!("expected SessionConfig variant"),
+        }
+    }
+
+    #[test]
+    fn client_message_tool_call_result_defaults_is_error_to_false() {
+        let json = r#"{"type":"tool_call.result","call_id":"abc","result":"ok"}"#;
+        let msg: ClientMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            ClientMessage::ToolCallResult {
+                call_id, is_error, ..
+            } => {
+                assert_eq!(call_id, "abc");
+                assert!(!is_error);
+            }
+            _ => panic!("expected ToolCallResult variant"),
+        }
+    }
+
+    #[test]
+    fn server_message_error_serializes_with_tag() {
+        let msg = ServerMessage::Error {
+            message: "boom".to_string(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert_eq!(json, r#"{"type":"error","message":"boom"}"#);
+    }
+}

--- a/gradbot_server/src/server.rs
+++ b/gradbot_server/src/server.rs
@@ -326,3 +326,41 @@ pub async fn serve(config: crate::config::Config) -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers_with_auth(value: &str) -> axum::http::HeaderMap {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            axum::http::HeaderValue::from_str(value).unwrap(),
+        );
+        headers
+    }
+
+    #[test]
+    fn extract_bearer_token_returns_token_for_bearer_scheme() {
+        let headers = headers_with_auth("Bearer abc123");
+        assert_eq!(extract_bearer_token(&headers), Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn extract_bearer_token_returns_none_when_header_missing() {
+        let headers = axum::http::HeaderMap::new();
+        assert_eq!(extract_bearer_token(&headers), None);
+    }
+
+    #[test]
+    fn extract_bearer_token_returns_none_for_non_bearer_scheme() {
+        let headers = headers_with_auth("Basic abc123");
+        assert_eq!(extract_bearer_token(&headers), None);
+    }
+
+    #[test]
+    fn extract_bearer_token_handles_empty_token() {
+        let headers = headers_with_auth("Bearer ");
+        assert_eq!(extract_bearer_token(&headers), Some("".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary
- `gradbot_server` had zero unit tests, unlike `gradbot_lib` and the OpenAI protocol binary in `src/`.
- Adds focused unit tests for the pure/testable logic in `protocol.rs`, `config.rs`, and `server.rs`:
  - `protocol.rs`: language code parsing/round-tripping, `SessionConfigWire` <-> `SessionConfig` conversion (defaults and explicit values), pinned-config merging, and wire-format (de)serialization of `ClientMessage`/`ServerMessage`.
  - `config.rs`: `$VAR` environment variable substitution, and `Config::load` defaults/overrides/env substitution end-to-end.
  - `server.rs`: Bearer token extraction from the WebSocket upgrade request's `Authorization` header.

No production code was changed — this is test-only.

## Test plan
- [x] `cargo test -p gradbot_server` — 21 tests, all passing
- [x] `cargo fmt -p gradbot_server -- --check`
- [x] `cargo clippy -p gradbot_server --tests -- -D warnings`